### PR TITLE
[#9] : Swagger 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.7.1'
+	id 'org.springframework.boot' version '2.5.3'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 }
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/itaxi/server/config/SwaggerConfig.java
+++ b/src/main/java/com/itaxi/server/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.itaxi.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.OAS_30)
+                .useDefaultResponseMessages(false)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.ant("/api/**"))
+                .build()
+                .apiInfo(apiInfo());
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("I-taxi Swagger")
+                .description("아이택시")
+                .version("1.0")
+                .build();
+    }
+}
+

--- a/src/main/java/com/itaxi/server/docs/ApiDoc.java
+++ b/src/main/java/com/itaxi/server/docs/ApiDoc.java
@@ -1,0 +1,5 @@
+package com.itaxi.server.docs;
+
+public class ApiDoc {
+    public static final String TEST = "테스트API";
+}

--- a/src/main/java/com/itaxi/server/post/presentation/PostController.java
+++ b/src/main/java/com/itaxi/server/post/presentation/PostController.java
@@ -1,5 +1,6 @@
 package com.itaxi.server.post.presentation;
 
+import com.itaxi.server.docs.ApiDoc;
 import com.itaxi.server.post.application.PostService;
 
 import org.springframework.http.ResponseEntity;
@@ -7,15 +8,18 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.annotations.ApiOperation;
+
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/post")
+@RequestMapping("/api/post")
 public class PostController {
     private final PostService postService;
 
     @GetMapping
+    @ApiOperation(value = ApiDoc.TEST)
     ResponseEntity<Object> aaa(){
         System.out.println("aaaa");
         return ResponseEntity.ok(null);


### PR DESCRIPTION
- Swagger 3.0에서는 최신 Spring 버전을 지원하지 않기 때문에 Spring Version을 2.7에서 2.5 버전으로 낮추었다.