### PR TITLE
feat[#28] : add specific function related status, owner in Post API

### DIFF
--- a/src/main/java/com/itaxi/server/exception/Message.java
+++ b/src/main/java/com/itaxi/server/exception/Message.java
@@ -10,4 +10,6 @@ public class Message {
     public static final String NOTICE_CONTENT_EMPTY_EXCEPTION = "공지사항의 내용이 없습니다";
     public static final String NOTICE_DELETED = "이미 삭제된 게시글입니다.";
     public static final String JOINER_DUPLICATE_MEMBER = "이미 해당 post에 존재하는 멤버입니다";
+    public static final String POST_MEMBER_FULL = "게시글의 인원이 이미 최대입니다.";
+    public static String Joiner_NOT_FOUND = "존재하지 않는 Joiner입니다.";
 }

--- a/src/main/java/com/itaxi/server/exception/post/JoinerDuplicateMemberException.java
+++ b/src/main/java/com/itaxi/server/exception/post/JoinerDuplicateMemberException.java
@@ -3,7 +3,7 @@ package com.itaxi.server.exception.post;
 import com.itaxi.server.exception.Message;
 import org.springframework.http.HttpStatus;
 
-public class JoinerDuplicateMemberException extends PostException {
+public class JoinerDuplicateMemberException extends JoinerException {
     public JoinerDuplicateMemberException(HttpStatus internalServerError) {
         super(Message.JOINER_DUPLICATE_MEMBER, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/itaxi/server/exception/post/JoinerException.java
+++ b/src/main/java/com/itaxi/server/exception/post/JoinerException.java
@@ -1,0 +1,11 @@
+package com.itaxi.server.exception.post;
+
+import com.itaxi.server.exception.ITaxiException;
+
+import org.springframework.http.HttpStatus;
+
+public class JoinerException extends ITaxiException {
+    public JoinerException(String message, HttpStatus httpStatus) {
+        super(message, httpStatus);
+    }
+}

--- a/src/main/java/com/itaxi/server/exception/post/JoinerNotFoundException.java
+++ b/src/main/java/com/itaxi/server/exception/post/JoinerNotFoundException.java
@@ -1,0 +1,10 @@
+package com.itaxi.server.exception.post;
+
+import com.itaxi.server.exception.Message;
+import org.springframework.http.HttpStatus;
+
+public class JoinerNotFoundException extends JoinerException {
+    public JoinerNotFoundException(HttpStatus internalServerError) {
+        super(Message.Joiner_NOT_FOUND, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/itaxi/server/exception/post/PostMemberFullException.java
+++ b/src/main/java/com/itaxi/server/exception/post/PostMemberFullException.java
@@ -1,0 +1,10 @@
+package com.itaxi.server.exception.post;
+
+import com.itaxi.server.exception.Message;
+import org.springframework.http.HttpStatus;
+
+public class PostMemberFullException extends PostException {
+    public PostMemberFullException(HttpStatus httpStatus) {
+        super(Message.POST_MEMBER_FULL, httpStatus);
+    }
+}

--- a/src/main/java/com/itaxi/server/post/domain/repository/JoinerRepository.java
+++ b/src/main/java/com/itaxi/server/post/domain/repository/JoinerRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 
 public interface JoinerRepository extends JpaRepository<Joiner, Long> {
     Optional<Joiner> findJoinerByPostAndMember(Post post, Member member);
-    List<Joiner> findJoinerByPost(Post post);
+    List<Joiner> findJoinersByPost(Post post);
 }

--- a/src/main/java/com/itaxi/server/post/presentation/PostController.java
+++ b/src/main/java/com/itaxi/server/post/presentation/PostController.java
@@ -94,7 +94,6 @@ public class PostController {
 
     @PostMapping("/{postId}/join")
     @ApiOperation(value = ApiDoc.JOIN_POST)
-    // TODO : 사람 다 찼을 때 모집 완료로 status 변경
     public ResponseEntity<PostInfoResponse> joinPost(@PathVariable Long postId, @RequestBody PostJoinRequest request) {
         PostInfoResponse result = postService.joinPost(postId, PostJoinDto.from(request, false));
 
@@ -103,7 +102,6 @@ public class PostController {
 
     @PutMapping("/{postId}/join")
     @ApiOperation(value = ApiDoc.EXIT_POST)
-    // TODO : 사람 다시 파졌을 때 모집 중으로 status 변경 + 방장 나가면 owner 바뀌게 ??
     public ResponseEntity<String> exitPost(@PathVariable Long postId, @RequestBody PostExitRequest request) {
         String result = postService.exitPost(postId, request.getUid());
 


### PR DESCRIPTION
Description
- PostController : remove TODO comment
- JoinerRepository : findJoinerByPost -> findJoinersByPost
- PostService : add PostMemberFullException, add owner and status related specific function
- PostMemberFullException : create PostMemberFullException
- JoinerNotFoundException : create JoinerNotFoundException
- JoinerException : create JoinerException
- JoinerDuplicateMemberException : change extends PostException -> JoinerException
- Message : add POST_MEMBER_FULL and Joiner_NOT_FOUND