### PR TITLE
refactor&fix[#25] : convention 통일, Member/Post 일부 API 오류수정

### DIFF
--- a/src/main/java/com/itaxi/server/exception/Message.java
+++ b/src/main/java/com/itaxi/server/exception/Message.java
@@ -6,6 +6,15 @@ public class Message {
     public static final String NOTICE_NOT_FOUND = "존재하지 않는 공지입니다.";
     public static final String POST_NOT_FOUND = "존재하지 않는 게시글입니다.";
 
+    /* Member 관련 추가 Exception Message */
+    public static final String MEMBER_CREATE_FAILED = "알 수 없는 오류로 인하여 회원가입에 실패하였습니다.";
+    public static final String MEMBER_UPDATE_FAILED = "알 수 없는 오류로 인하여 회원정보 수정에 실패하였습니다.";
+    public static final String MEMBER_DELETE_FAILED = "알 수 없는 오류로 인하여 회원정보 삭제에 실패하였습니다.";
+    public static final String MEMBER_UID_ISNULL = "UID 값이 올바르지 않습니다.";
+    public static final String MEMBER_EMAIL_ISNULL = "Email 값이 올바르지 않습니다.";
+    public static final String MEMBER_PHONE_ISNULL = "연락처 값이 올바르지 않습니다.";
+    public static final String MEMBER_NAME_ISNULL = "사용자 이름 값이 올바르지 않습니다.";
+
     public static final String NOTICE_TITLE_EMPTY_EXCEPTION = "공지사항의 제목이 없습니다";
     public static final String NOTICE_CONTENT_EMPTY_EXCEPTION = "공지사항의 내용이 없습니다";
     public static final String NOTICE_DELETED = "이미 삭제된 게시글입니다.";

--- a/src/main/java/com/itaxi/server/exception/member/MemberCreateFailedException.java
+++ b/src/main/java/com/itaxi/server/exception/member/MemberCreateFailedException.java
@@ -1,0 +1,10 @@
+package com.itaxi.server.exception.member;
+
+import com.itaxi.server.exception.Message;
+import org.springframework.http.HttpStatus;
+
+public class MemberCreateFailedException extends MemberException {
+    public MemberCreateFailedException(HttpStatus httpStatus) {
+        super(Message.MEMBER_CREATE_FAILED, httpStatus);
+    }
+}

--- a/src/main/java/com/itaxi/server/exception/member/MemberDeleteFailedException.java
+++ b/src/main/java/com/itaxi/server/exception/member/MemberDeleteFailedException.java
@@ -1,0 +1,10 @@
+package com.itaxi.server.exception.member;
+
+import com.itaxi.server.exception.Message;
+import org.springframework.http.HttpStatus;
+
+public class MemberDeleteFailedException extends MemberException {
+    public MemberDeleteFailedException(HttpStatus httpStatus) {
+        super(Message.MEMBER_DELETE_FAILED, httpStatus);
+    }
+}

--- a/src/main/java/com/itaxi/server/exception/member/MemberEmailNullException.java
+++ b/src/main/java/com/itaxi/server/exception/member/MemberEmailNullException.java
@@ -1,0 +1,10 @@
+package com.itaxi.server.exception.member;
+
+import com.itaxi.server.exception.Message;
+import org.springframework.http.HttpStatus;
+
+public class MemberEmailNullException extends MemberException {
+    public MemberEmailNullException(HttpStatus httpStatus) {
+        super(Message.MEMBER_EMAIL_ISNULL, httpStatus);
+    }
+}

--- a/src/main/java/com/itaxi/server/exception/member/MemberNameNullException.java
+++ b/src/main/java/com/itaxi/server/exception/member/MemberNameNullException.java
@@ -1,0 +1,10 @@
+package com.itaxi.server.exception.member;
+
+import com.itaxi.server.exception.Message;
+import org.springframework.http.HttpStatus;
+
+public class MemberNameNullException extends MemberException {
+    public MemberNameNullException(HttpStatus httpStatus) {
+        super(Message.MEMBER_NAME_ISNULL, httpStatus);
+    }
+}

--- a/src/main/java/com/itaxi/server/exception/member/MemberPhoneNullException.java
+++ b/src/main/java/com/itaxi/server/exception/member/MemberPhoneNullException.java
@@ -1,0 +1,10 @@
+package com.itaxi.server.exception.member;
+
+import com.itaxi.server.exception.Message;
+import org.springframework.http.HttpStatus;
+
+public class MemberPhoneNullException extends MemberException {
+    public MemberPhoneNullException(HttpStatus httpStatus) {
+        super(Message.MEMBER_PHONE_ISNULL, httpStatus);
+    }
+}

--- a/src/main/java/com/itaxi/server/exception/member/MemberUidNullException.java
+++ b/src/main/java/com/itaxi/server/exception/member/MemberUidNullException.java
@@ -1,0 +1,10 @@
+package com.itaxi.server.exception.member;
+
+import com.itaxi.server.exception.Message;
+import org.springframework.http.HttpStatus;
+
+public class MemberUidNullException extends MemberException {
+    public MemberUidNullException(HttpStatus httpStatus) {
+        super(Message.MEMBER_UID_ISNULL, httpStatus);
+    }
+}

--- a/src/main/java/com/itaxi/server/exception/member/MemberUpdateFailedException.java
+++ b/src/main/java/com/itaxi/server/exception/member/MemberUpdateFailedException.java
@@ -1,0 +1,10 @@
+package com.itaxi.server.exception.member;
+
+import com.itaxi.server.exception.Message;
+import org.springframework.http.HttpStatus;
+
+public class MemberUpdateFailedException extends MemberException {
+    public MemberUpdateFailedException(HttpStatus httpStatus) {
+        super(Message.MEMBER_UPDATE_FAILED, httpStatus);
+    }
+}

--- a/src/main/java/com/itaxi/server/member/domain/Member.java
+++ b/src/main/java/com/itaxi/server/member/domain/Member.java
@@ -5,27 +5,39 @@ import java.util.List;
 import javax.persistence.*;
 
 import com.itaxi.server.common.BaseEntity;
+import com.itaxi.server.exception.member.MemberEmailNullException;
+import com.itaxi.server.exception.member.MemberNameNullException;
+import com.itaxi.server.exception.member.MemberPhoneNullException;
+import com.itaxi.server.exception.member.MemberUidNullException;
+import com.itaxi.server.member.domain.dto.MemberCreateRequestDTO;
 import com.itaxi.server.post.domain.Joiner;
 import com.itaxi.server.report.domain.Report;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.http.HttpStatus;
 
 @Entity
 @Getter
 @Setter
+@NoArgsConstructor
 public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private String uid;
 
+    @Column(unique = true)
     private String email;
 
+    @Column(unique = true)
     private String phone;
 
+    @Column(unique = true)
     private String name;
 
     private String bank;
@@ -39,4 +51,29 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "writer")
     private List<Report> reports = new ArrayList<>();
+
+    public Member(MemberCreateRequestDTO memberCreateRequestDTO) {
+        this.uid = memberCreateRequestDTO.getUid();
+        this.email = memberCreateRequestDTO.getEmail();
+        this.phone = memberCreateRequestDTO.getPhone();
+        this.name = memberCreateRequestDTO.getName();
+        this.bank = memberCreateRequestDTO.getBank();
+        this.bankAddress = memberCreateRequestDTO.getBankAddress();
+
+        /* data validation - uid */
+        if(this.uid == null || this.uid.trim().isEmpty())
+            throw new MemberUidNullException(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        /* data validation - email */
+        if(this.email == null || this.email.trim().isEmpty())
+            throw new MemberEmailNullException(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        /* data validation - phone */
+        if(this.phone == null || this.phone.trim().isEmpty())
+            throw new MemberPhoneNullException(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        /* data validation - name */
+        if(this.name == null || this.name.trim().isEmpty())
+            throw new MemberNameNullException(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 }

--- a/src/main/java/com/itaxi/server/member/domain/dto/MemberCreateRequestDTO.java
+++ b/src/main/java/com/itaxi/server/member/domain/dto/MemberCreateRequestDTO.java
@@ -1,0 +1,17 @@
+package com.itaxi.server.member.domain.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MemberCreateRequestDTO {
+    private String uid;
+    private String email;
+    private String phone;
+    private String name;
+    private String bank;
+    private String bankAddress;
+}

--- a/src/main/java/com/itaxi/server/member/domain/dto/MemberJoinInfo.java
+++ b/src/main/java/com/itaxi/server/member/domain/dto/MemberJoinInfo.java
@@ -16,7 +16,9 @@ public class MemberJoinInfo {
     public MemberJoinInfo(Member m) {
         List<Joiner> joiners = m.getJoiners();
         this.posts = new ArrayList<>();
-        for(Joiner joiner : joiners)
-            posts.add(joiner.getPost());
+        for(Joiner joiner : joiners) {
+            if(joiner.getStatus() == 1)
+                posts.add(joiner.getPost());
+        }
     }
 }

--- a/src/main/java/com/itaxi/server/member/domain/dto/MemberUidDTO.java
+++ b/src/main/java/com/itaxi/server/member/domain/dto/MemberUidDTO.java
@@ -1,0 +1,12 @@
+package com.itaxi.server.member.domain.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MemberUidDTO {
+    private String uid;
+}

--- a/src/main/java/com/itaxi/server/member/domain/dto/MemberUpdateRequestDTO.java
+++ b/src/main/java/com/itaxi/server/member/domain/dto/MemberUpdateRequestDTO.java
@@ -1,0 +1,15 @@
+package com.itaxi.server.member.domain.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MemberUpdateRequestDTO {
+    private String uid;
+    private String phone;
+    private String bank;
+    private String bankAddress;
+}

--- a/src/main/java/com/itaxi/server/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/itaxi/server/member/domain/repository/MemberRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findMemberByUid(String uid);
-    Optional<MemberInfo> findMemberInfoByUid(String uid);
-    Optional<LoginResponse> findMemberForLoginByUid(String uid);
+    Optional<Member> findMemberByUidAndDeletedFalse(String uid);
+    Optional<MemberInfo> findMemberInfoByUidAndDeletedFalse(String uid);
+    Optional<LoginResponse> findMemberForLoginByUidAndDeletedFalse(String uid);
 }

--- a/src/main/java/com/itaxi/server/member/presentation/MemberController.java
+++ b/src/main/java/com/itaxi/server/member/presentation/MemberController.java
@@ -2,11 +2,8 @@ package com.itaxi.server.member.presentation;
 
 import com.itaxi.server.docs.ApiDoc;
 import com.itaxi.server.member.application.MemberService;
-import com.itaxi.server.member.domain.Member;
-import com.itaxi.server.member.domain.dto.LoginResponse;
-import com.itaxi.server.member.domain.dto.MemberInfo;
+import com.itaxi.server.member.domain.dto.*;
 
-import com.itaxi.server.member.domain.dto.MemberJoinInfo;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,49 +21,34 @@ public class MemberController {
     /* CREATE */
     @ApiOperation(value = ApiDoc.MEMBER_CREATE)
     @PostMapping(value = "")
-    public String createMember(HttpServletRequest httpServletRequest) {
-        String uid = httpServletRequest.getParameter("uid");
-        String email = httpServletRequest.getParameter("email");
-        String phone = httpServletRequest.getParameter("phone");
-        String name = httpServletRequest.getParameter("name");
-        String bank = httpServletRequest.getParameter("bank");
-        String bankAddress = httpServletRequest.getParameter("bankAddress");
-
-        return memberService.createMember(uid, email, phone, name, bank, bankAddress);
+    public String createMember(@RequestBody MemberCreateRequestDTO memberCreateRequestDTO) {
+        return memberService.createMember(memberCreateRequestDTO);
     }
 
     /* READ */
     @ApiOperation(value = ApiDoc.MEMBER_READ)
     @GetMapping(value = "")
-    public MemberInfo getMember(HttpServletRequest httpServletRequest) {
-        String uid = httpServletRequest.getParameter("uid");
-        return memberService.getMember(uid);
+    public MemberInfo getMember(@RequestBody MemberUidDTO memberUidDTO) {
+        return memberService.getMember(memberUidDTO.getUid());
     }
 
     @ApiOperation(value = ApiDoc.MEMBER_LOGIN)
     @GetMapping(value = "/login")
-    public LoginResponse login(HttpServletRequest httpServletRequest) {
-        String uid = httpServletRequest.getParameter("uid");
-        return memberService.login(uid);
+    public LoginResponse login(@RequestBody MemberUidDTO memberUidDTO) {
+        return memberService.login(memberUidDTO.getUid());
     }
 
     /* UPDATE */
     @ApiOperation(value = ApiDoc.MEMBER_UPDATE)
     @PatchMapping(value = "")
-    public String updateMember(HttpServletRequest httpServletRequest) {
-        String uid = httpServletRequest.getParameter("uid");
-        String phone = httpServletRequest.getParameter("phone");
-        String bank = httpServletRequest.getParameter("bank");
-        String bankAddress = httpServletRequest.getParameter("bankAddress");
-
-        return memberService.updateMember(uid, phone, bank, bankAddress);
+    public String updateMember(@RequestBody MemberUpdateRequestDTO memberUpdateRequestDTO) {
+        return memberService.updateMember(memberUpdateRequestDTO);
     }
 
     /* DELETE */
     @ApiOperation(value = ApiDoc.MEMBER_DELETE)
     @PatchMapping(value = "/resign")
-    public String deleteMember(HttpServletRequest httpServletRequest) {
-        String uid = httpServletRequest.getParameter("uid");
-        return memberService.deleteMember(uid);
+    public String deleteMember(@RequestBody MemberUidDTO memberUidDTO) {
+        return memberService.deleteMember(memberUidDTO.getUid());
     }
 }

--- a/src/main/java/com/itaxi/server/post/application/PostService.java
+++ b/src/main/java/com/itaxi/server/post/application/PostService.java
@@ -30,22 +30,21 @@ public class PostService {
     private final JoinerRepository joinerRepository;
 
     public List<PostLog> getPostLog(String uid) {
-        Optional<Member> member = memberRepository.findMemberByUid(uid);
-        if(member.isPresent()) {
-            MemberJoinInfo joinInfo = new MemberJoinInfo(member.get());
-            List<PostLog> postLogs = new ArrayList<>();
-            for(Post post : joinInfo.getPosts())
-                postLogs.add(new PostLog(post));
-            return postLogs;
-        }
-        throw new MemberNotFoundException(HttpStatus.INTERNAL_SERVER_ERROR);
+        Optional<Member> member = memberRepository.findMemberByUidAndDeletedFalse(uid);
+        if(!member.isPresent())
+            throw new MemberNotFoundException(HttpStatus.INTERNAL_SERVER_ERROR);
+        MemberJoinInfo joinInfo = new MemberJoinInfo(member.get());
+        List<PostLog> postLogs = new ArrayList<>();
+        for(Post post : joinInfo.getPosts())
+            postLogs.add(new PostLog(post));
+        return postLogs;
     }
 
     public PostLogDetail getPostLogDetail(Long postId) {
         Optional<Post> post = postRepository.findById(postId);
-        if(post.isPresent())
-            return new PostLogDetail(post.get());
-        throw new PostNotFoundException(HttpStatus.INTERNAL_SERVER_ERROR);
+        if(!post.isPresent())
+            throw new PostNotFoundException(HttpStatus.INTERNAL_SERVER_ERROR);
+        return new PostLogDetail(post.get());
     }
 
     public Post create(PostDto.AddPostPlaceReq dto) {
@@ -70,7 +69,7 @@ public class PostService {
 
         // Member에서 UID 가진 Member 찾기
         try {
-            Optional<Member> member = memberRepository.findMemberByUid(postJoinDto.getUid());
+            Optional<Member> member = memberRepository.findMemberByUidAndDeletedFalse(postJoinDto.getUid());
             if (member.isPresent()) {
                 memberInfo = member.get();
             } else {
@@ -111,7 +110,7 @@ public class PostService {
 
         // Member에서 UID 가진 Member 찾기
         try {
-            Optional<Member> member = memberRepository.findMemberByUid(uid);
+            Optional<Member> member = memberRepository.findMemberByUidAndDeletedFalse(uid);
             if (member.isPresent()) {
                 memberInfo = member.get();
             } else {

--- a/src/main/java/com/itaxi/server/post/domain/dto/PostLog.java
+++ b/src/main/java/com/itaxi/server/post/domain/dto/PostLog.java
@@ -1,6 +1,7 @@
 package com.itaxi.server.post.domain.dto;
 
 import com.itaxi.server.place.domain.Place;
+import com.itaxi.server.post.domain.Joiner;
 import com.itaxi.server.post.domain.Post;
 
 import java.time.LocalDateTime;
@@ -23,6 +24,11 @@ public class PostLog {
         this.deptTime = p.getDeptTime();
         this.capacity = p.getCapacity();
         this.status = p.getStatus();
-        this.participantNum = p.getJoiners().size();
+        int tmp = 0;
+        for(Joiner joiner : p.getJoiners()) {
+            if(joiner.getStatus() == 1)
+                tmp += 1;
+        }
+        this.participantNum = tmp;
     }
 }

--- a/src/main/java/com/itaxi/server/post/domain/dto/PostLogDetail.java
+++ b/src/main/java/com/itaxi/server/post/domain/dto/PostLogDetail.java
@@ -9,12 +9,14 @@ import java.util.List;
 
 @Getter
 public class PostLogDetail extends PostLog {
-    private List<JoinerInfo> joiners;
+    private final List<JoinerInfo> joiners;
 
     public PostLogDetail(Post p) {
         super(p);
         joiners = new ArrayList<>();
-        for(Joiner joiner : p.getJoiners())
-            joiners.add(new JoinerInfo(joiner));
+        for(Joiner joiner : p.getJoiners()) {
+            if (joiner.getStatus() == 1)
+                joiners.add(new JoinerInfo(joiner));
+        }
     }
 }

--- a/src/main/java/com/itaxi/server/post/presentation/PostController.java
+++ b/src/main/java/com/itaxi/server/post/presentation/PostController.java
@@ -1,5 +1,6 @@
 package com.itaxi.server.post.presentation;
 
+import com.itaxi.server.member.domain.dto.MemberUidDTO;
 import io.swagger.annotations.Api;
 import org.springframework.http.HttpStatus;
 import com.itaxi.server.docs.ApiDoc;
@@ -45,9 +46,8 @@ public class PostController {
 
     @ApiOperation(value = ApiDoc.POST_HISTORY)
     @GetMapping(value = "history")
-    public List<PostLog> getPostLog(HttpServletRequest httpServletRequest) {
-        String uid = httpServletRequest.getParameter("uid");
-        return postService.getPostLog(uid);
+    public List<PostLog> getPostLog(@RequestBody MemberUidDTO memberUidDTO) {
+        return postService.getPostLog(memberUidDTO.getUid());
     }
 
     @ApiOperation(value = ApiDoc.POST_HISTORY_DETAIL)


### PR DESCRIPTION
### 수행한 작업
1. 서로 달랐던 code convention 통일
2. Member Repository 수정 (삭제된 멤버는 조회할 수 없도록)
3. HttpServletRequest => @RequestBody 로 교체 (Member, Post API)
4. 각 API 별 Exception 처리 보강
5. Post History 관련 API status 미확인 문제 수정 (방을 나간 멤버도 joiners로 넘어오는 문제)