### PR TITLE
fix[#47] : fix http method of Member, Post history related APIs

### DIFF
--- a/src/main/java/com/itaxi/server/member/presentation/MemberController.java
+++ b/src/main/java/com/itaxi/server/member/presentation/MemberController.java
@@ -27,13 +27,13 @@ public class MemberController {
 
     /* READ */
     @ApiOperation(value = ApiDoc.MEMBER_READ)
-    @GetMapping(value = "")
+    @PostMapping(value = "/info")
     public MemberInfo getMember(@RequestBody MemberUidDTO memberUidDTO) {
         return memberService.getMember(memberUidDTO.getUid());
     }
 
     @ApiOperation(value = ApiDoc.MEMBER_LOGIN)
-    @GetMapping(value = "/login")
+    @PostMapping(value = "/login")
     public LoginResponse login(@RequestBody MemberUidDTO memberUidDTO) {
         return memberService.login(memberUidDTO.getUid());
     }

--- a/src/main/java/com/itaxi/server/post/presentation/PostController.java
+++ b/src/main/java/com/itaxi/server/post/presentation/PostController.java
@@ -44,7 +44,7 @@ public class PostController {
     private final PlaceRepository placeRepository;
 
     @ApiOperation(value = ApiDoc.POST_HISTORY)
-    @GetMapping(value = "history")
+    @PostMapping(value = "history")
     public List<PostLog> getPostLog(@RequestBody MemberUidDTO memberUidDTO) {
         return postService.getPostLog(memberUidDTO.getUid());
     }


### PR DESCRIPTION
Member와 Post History 쪽 일부 API에서 body로 요청을 보내는 GET 요청이 존재하여 해당 사항 수정함.
수정과정에서 Member READ와 관련된 API가 Create와 HTTP method, url pattern이 중복되는 현상이 발생하여 /info로 url 변경함