### PR TITLE
[fix/#134] : API 권한 설정  및 API 명세에 맞게 RequestBody 교체

### DIFF
--- a/src/main/java/com/itaxi/server/banner/application/BannerService.java
+++ b/src/main/java/com/itaxi/server/banner/application/BannerService.java
@@ -2,6 +2,7 @@ package com.itaxi.server.banner.application;
 
 import com.itaxi.server.banner.application.dto.BannerCreateDto;
 import com.itaxi.server.banner.application.dto.BannerCreateEntityDto;
+import com.itaxi.server.banner.application.dto.BannerDeleteDto;
 import com.itaxi.server.banner.application.dto.BannerUpdateDto;
 import com.itaxi.server.banner.domain.Banner;
 import com.itaxi.server.banner.domain.repository.BannerRepository;
@@ -101,6 +102,10 @@ public class BannerService {
 
         if(!(banner.isPresent())) throw
                 new BannerNotFoundException(HttpStatus.INTERNAL_SERVER_ERROR);
+
+
+        if (! banner.get().getUid().equals(bannerUpdateDto.getUid())) throw
+                new BannerNoAuthorityException();
 
         Banner bannerInfo = banner.get();
         bannerInfo.setWeatherStatus(bannerUpdateDto.getWeatherStatus());
@@ -240,8 +245,10 @@ public class BannerService {
     }
 
     @Transactional
-    public String deleteBanner(Long bannerId){
+    public String deleteBanner(Long bannerId, BannerDeleteDto bannerDeleteDto){
         Optional<Banner> banner = bannerRepository.findById(bannerId);
+        if(!(banner.get().getUid().equals(bannerDeleteDto.getUid()))) throw
+            new BannerNoAuthorityException();
         if(banner.isPresent()){
             Banner bannerInfo = banner.get();
             bannerInfo.setDeleted(true);

--- a/src/main/java/com/itaxi/server/banner/application/dto/BannerDeleteDto.java
+++ b/src/main/java/com/itaxi/server/banner/application/dto/BannerDeleteDto.java
@@ -1,0 +1,17 @@
+package com.itaxi.server.banner.application.dto;
+
+import com.itaxi.server.banner.presentation.request.BannerDeleteRequest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BannerDeleteDto {
+    private String uid;
+
+    public static BannerDeleteDto from(BannerDeleteRequest request){
+        return new BannerDeleteDto(request.getUid());
+    }
+}

--- a/src/main/java/com/itaxi/server/banner/application/dto/BannerUpdateDto.java
+++ b/src/main/java/com/itaxi/server/banner/application/dto/BannerUpdateDto.java
@@ -12,7 +12,9 @@ public class BannerUpdateDto {
     private int weatherStatus;
     private Long depId;
     private Long desId;
+
+    private String uid;
     public static BannerUpdateDto from(BannerUpdateRequest request) {
-        return new BannerUpdateDto( request.getWeatherStatus(),request.getDepId(),request.getDesId());
+        return new BannerUpdateDto( request.getWeatherStatus(),request.getDepId(),request.getDesId(), request.getUid());
     }
 }

--- a/src/main/java/com/itaxi/server/banner/presentation/BannerController.java
+++ b/src/main/java/com/itaxi/server/banner/presentation/BannerController.java
@@ -56,7 +56,7 @@ public class BannerController {
 
     @ApiOperation(value = ApiDoc.BANNER_READ_RECENT_ALL)
     @GetMapping("/recent")
-    public ResponseEntity<List> readAllRecentBanner(@RequestParam(required = false)@DateTimeFormat(iso= DateTimeFormat.ISO.DATE_TIME) final LocalDateTime time) {
+    public ResponseEntity<List> readAllRecentBanner(@RequestParam @DateTimeFormat(iso= DateTimeFormat.ISO.DATE_TIME) final LocalDateTime time) {
         if(time==null) throw new BannerRequestBodyException(HttpStatus.INTERNAL_SERVER_ERROR);
         List<BannerReadAllRecentResponse> result = bannerService.readAllRecentBanners(time);
         return ResponseEntity.ok(result);
@@ -65,8 +65,8 @@ public class BannerController {
     @Transactional
     @ApiOperation(value = ApiDoc.BANNER_DELETE)
     @DeleteMapping("/{bannerId}")
-    public ResponseEntity<String> deleteBanner(@PathVariable Long bannerId){
-        String result = bannerService.deleteBanner(bannerId);
+    public ResponseEntity<String> deleteBanner(@PathVariable Long bannerId, @RequestBody BannerDeleteRequest request){
+        String result = bannerService.deleteBanner(bannerId,BannerDeleteDto.from(request));
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/itaxi/server/banner/presentation/request/BannerDeleteRequest.java
+++ b/src/main/java/com/itaxi/server/banner/presentation/request/BannerDeleteRequest.java
@@ -1,0 +1,8 @@
+package com.itaxi.server.banner.presentation.request;
+
+import lombok.Getter;
+
+@Getter
+public class BannerDeleteRequest {
+    private String uid;
+}

--- a/src/main/java/com/itaxi/server/banner/presentation/request/BannerUpdateRequest.java
+++ b/src/main/java/com/itaxi/server/banner/presentation/request/BannerUpdateRequest.java
@@ -11,4 +11,5 @@ public class BannerUpdateRequest {
     private int weatherStatus;
     private Long depId;
     private Long desId;
+    private String uid;
 }

--- a/src/main/java/com/itaxi/server/exception/Message.java
+++ b/src/main/java/com/itaxi/server/exception/Message.java
@@ -47,6 +47,7 @@ public class Message {
     public static final String BANNER_BAD_WEATHER_STATUS_EXCEPTION = "존재하지 않는 날씨 상태입니다.";
     public static final String BANNER_BAD_REPORT_TIME_EXCEPTION = "현재 시간보다 이전에 제보할 수 없습니다.";
     public static final String BANNER_REQUEST_BODY_EXCEPTION = "올바르지 않은 형식으로 데이터가 전달 되었습니다.";
+    public static final String BANNER_NO_AUTHORITY_EXCEPTION = "본 요청에 대한 권한이 존재하지 않습니다.";
     public static final String BANNER_PLACE_CNT_MINUS_EXCEPTION = "조회수는 0보다 작을 수 없습니다.";
     public static final String BANNER_PLACE_NAME_NULL_EXCEPTION = "장소의 이름은 null값일 수 없습니다.";
     public static final String BANNER_PLACE_REQUEST_BODY_EXCEPTION = "올바르지 않은 형식으로 데이터가 전달 되었습니다.";
@@ -65,4 +66,5 @@ public class Message {
 
 
     public static final String FAVOR_JOINER_DUPLICATED = "이미 즐겨찾기로 등록된 장소입니다.";
+    public static final String FAVOR_NO_AUTHORITY_EXCEPTION = "본 요청에 대한 권한이 존재하지 않습니다.";
 }

--- a/src/main/java/com/itaxi/server/exception/banner/BannerNoAuthorityException.java
+++ b/src/main/java/com/itaxi/server/exception/banner/BannerNoAuthorityException.java
@@ -1,0 +1,10 @@
+package com.itaxi.server.exception.banner;
+
+import com.itaxi.server.exception.Message;
+import org.springframework.http.HttpStatus;
+
+public class BannerNoAuthorityException extends BannerException{
+    public BannerNoAuthorityException(){
+        super(Message.BANNER_NO_AUTHORITY_EXCEPTION, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/itaxi/server/exception/favorite/FavorDuplicatedException.java
+++ b/src/main/java/com/itaxi/server/exception/favorite/FavorDuplicatedException.java
@@ -1,11 +1,10 @@
 package com.itaxi.server.exception.favorite;
 
 import com.itaxi.server.exception.Message;
-import com.itaxi.server.exception.member.MemberException;
 import org.springframework.http.HttpStatus;
 
-public class FavorDuplicatedException extends MemberException {
-    public FavorDuplicatedException(HttpStatus httpStatus){
-        super(Message.FAVOR_JOINER_DUPLICATED, httpStatus);
+public class FavorDuplicatedException extends FavoriteException {
+    public FavorDuplicatedException(){
+        super(Message.FAVOR_JOINER_DUPLICATED, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/itaxi/server/exception/favorite/FavorNoAuthorityException.java
+++ b/src/main/java/com/itaxi/server/exception/favorite/FavorNoAuthorityException.java
@@ -1,0 +1,8 @@
+package com.itaxi.server.exception.favorite;
+
+import com.itaxi.server.exception.Message;
+import org.springframework.http.HttpStatus;
+
+public class FavorNoAuthorityException extends FavoriteException{
+    public FavorNoAuthorityException(){super(Message.FAVOR_NO_AUTHORITY_EXCEPTION, HttpStatus.BAD_REQUEST);}
+}

--- a/src/main/java/com/itaxi/server/exception/favorite/FavoriteException.java
+++ b/src/main/java/com/itaxi/server/exception/favorite/FavoriteException.java
@@ -1,0 +1,8 @@
+package com.itaxi.server.exception.favorite;
+
+import com.itaxi.server.exception.ITaxiException;
+import org.springframework.http.HttpStatus;
+
+public class FavoriteException extends ITaxiException {
+    public FavoriteException(String message, HttpStatus httpStatus){super(message, httpStatus);}
+}

--- a/src/main/java/com/itaxi/server/favorite/application/dto/FavorJoinerCreateDto.java
+++ b/src/main/java/com/itaxi/server/favorite/application/dto/FavorJoinerCreateDto.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FavorJoinerCreateDto {
-    private String memberUid;
+    private String uid;
     private Long placeId;
 }

--- a/src/main/java/com/itaxi/server/favorite/presentation/FavorJoinerController.java
+++ b/src/main/java/com/itaxi/server/favorite/presentation/FavorJoinerController.java
@@ -2,6 +2,7 @@ package com.itaxi.server.favorite.presentation;
 import com.itaxi.server.docs.ApiDoc;
 import com.itaxi.server.favorite.application.FavorJoinerService;
 import com.itaxi.server.favorite.application.dto.FavorJoinerCreateDto;
+import com.itaxi.server.favorite.presentation.request.FavorDeleteRequest;
 import com.itaxi.server.favorite.presentation.request.FavorReadRequest;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -30,9 +31,9 @@ public class FavorJoinerController {
     }
 
     @ApiOperation(value = ApiDoc.FAVORITE_JOINER_DELETE)
-    @PatchMapping(value = "/{favorId}")
-    public ResponseEntity<String> deleteFavorite(@PathVariable Long favorId ) {
-        return ResponseEntity.ok(favorJoinerService.deleteFavorite(favorId));
+    @DeleteMapping(value = "/{favorId}")
+    public ResponseEntity<String> deleteFavorite(@PathVariable Long favorId, @RequestBody FavorDeleteRequest request) {
+        return ResponseEntity.ok(favorJoinerService.deleteFavorite(favorId,request));
     }
 
 

--- a/src/main/java/com/itaxi/server/favorite/presentation/request/FavorDeleteRequest.java
+++ b/src/main/java/com/itaxi/server/favorite/presentation/request/FavorDeleteRequest.java
@@ -1,0 +1,8 @@
+package com.itaxi.server.favorite.presentation.request;
+
+import lombok.Getter;
+
+@Getter
+public class FavorDeleteRequest {
+    public String uid;
+}

--- a/src/main/java/com/itaxi/server/notice/application/NoticeService.java
+++ b/src/main/java/com/itaxi/server/notice/application/NoticeService.java
@@ -94,8 +94,6 @@ public class NoticeService {
 
             noticeInfo.setTitle(noticeUpdateDto.getTitle());
             noticeInfo.setContent(noticeUpdateDto.getContent());
-            noticeInfo.setStartTime(noticeUpdateDto.getStartTime());
-            noticeInfo.setEndTime(noticeUpdateDto.getEndTime());
             if((noticeInfo.getNoticeType()==2 || noticeInfo.getNoticeType()==3)  &&
                     (noticeInfo.getStartTime() == null || noticeInfo.getEndTime() == null ))
                 throw new NoticeElementNotMatchWithNoticeTypeException();

--- a/src/main/java/com/itaxi/server/notice/application/dto/NoticeUpdateDto.java
+++ b/src/main/java/com/itaxi/server/notice/application/dto/NoticeUpdateDto.java
@@ -13,10 +13,9 @@ import java.time.LocalDateTime;
 public class NoticeUpdateDto {
     private String title;
     private String content;
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
+
 
     public static NoticeUpdateDto from(NoticeUpdateRequest request) {
-        return new NoticeUpdateDto(request.getTitle(), request.getContent(),request.getStartTime(),request.getEndTime());
+        return new NoticeUpdateDto(request.getTitle(), request.getContent());
     }
 }

--- a/src/main/java/com/itaxi/server/notice/presentation/request/NoticeUpdateRequest.java
+++ b/src/main/java/com/itaxi/server/notice/presentation/request/NoticeUpdateRequest.java
@@ -12,8 +12,5 @@ import java.time.LocalDateTime;
 public class NoticeUpdateRequest {
     private String title;
     private String content;
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
-    private int bannerType;
     private String uid;
 }

--- a/src/main/java/com/itaxi/server/place/application/PlaceService.java
+++ b/src/main/java/com/itaxi/server/place/application/PlaceService.java
@@ -1,7 +1,9 @@
 package com.itaxi.server.place.application;
 import com.itaxi.server.cheaker.AdminChecker;
 import com.itaxi.server.exception.member.MemberNotAdminException;
+import com.itaxi.server.exception.notice.NoticeNotFoundException;
 import com.itaxi.server.exception.place.*;
+import com.itaxi.server.notice.domain.Notice;
 import com.itaxi.server.place.application.dto.AddPlaceDto;
 import com.itaxi.server.place.application.dto.UpdatePlaceDto;
 import com.itaxi.server.place.domain.repository.PlaceRepository;
@@ -100,8 +102,18 @@ public class PlaceService {
     }
 
     @Transactional
-    public int updateView(Long id) {
-        return placeRepository.updateView(id);
+    public Long updateView(Long id) {
+        Place placeInfo  = null;
+        Optional<Place> place = placeRepository.findById(id);
+        if (place.isPresent()) {
+            placeInfo = place.get();
+            placeInfo.setCnt(placeInfo.getCnt() + 1);
+            placeRepository.save(placeInfo);
+        } else {
+            throw new PlaceNotFoundException();
+        }
+
+        return placeInfo.getCnt();
     }
 }
 

--- a/src/main/java/com/itaxi/server/place/domain/Place.java
+++ b/src/main/java/com/itaxi/server/place/domain/Place.java
@@ -6,10 +6,7 @@ import javax.validation.constraints.NotBlank;
 import com.itaxi.server.common.BaseEntity;
 import com.itaxi.server.favorite.domain.FavorJoiner;
 import com.itaxi.server.place.application.dto.UpdatePlaceDto;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.Where;
 
@@ -19,6 +16,7 @@ import java.util.List;
 @Where(clause = "deleted=false")
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicUpdate
 public class Place extends BaseEntity {

--- a/src/main/java/com/itaxi/server/place/domain/repository/PlaceRepository.java
+++ b/src/main/java/com/itaxi/server/place/domain/repository/PlaceRepository.java
@@ -15,8 +15,5 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     @Query("SELECT p FROM Place p WHERE  p.deleted = false order by p.cnt desc NULLS LAST")
     Iterable<Place> findByDeleted();
 
-    @Modifying(clearAutomatically = true)
-    @Query("update Place p set p.cnt = p.cnt + 1 where p.id = :id")
-    int updateView(Long id);
 
 }

--- a/src/main/java/com/itaxi/server/place/presentation/PlaceController.java
+++ b/src/main/java/com/itaxi/server/place/presentation/PlaceController.java
@@ -41,7 +41,7 @@ public class PlaceController {
 
     @ApiOperation(value = ApiDoc.PLACE_UPDATE_COUNT)
     @RequestMapping(value = "/count/{id}", method = RequestMethod.PUT)
-    public ResponseEntity<Integer> updateView(@PathVariable final long id, Model model) {
+    public ResponseEntity<Long> updateView(@PathVariable final long id, Model model) {
         return ResponseEntity.ok(placeService.updateView(id));
     }
     @ApiOperation(value = ApiDoc.PLACE_UPDATE)


### PR DESCRIPTION
- banner edit delete 권한 설정
- favorite delete 권한 설정
- Notice RequestBody API 명세에 맞게 변경
- Place count 증가 함수 query문 삭제