### PR TITLE
Fix/#170 : 재회원가입 로직 수정 및 도중 탈퇴 에러 메세지 수정

### DIFF
--- a/src/main/java/com/itaxi/server/exception/Message.java
+++ b/src/main/java/com/itaxi/server/exception/Message.java
@@ -21,6 +21,7 @@ public class Message {
     public static final String MEMBER_CREATE_FAILED = "알 수 없는 오류로 인하여 회원가입에 실패하였습니다.";
     public static final String MEMBER_UPDATE_FAILED = "알 수 없는 오류로 인하여 회원정보 수정에 실패하였습니다.";
     public static final String MEMBER_DELETE_FAILED = "알 수 없는 오류로 인하여 회원정보 삭제에 실패하였습니다.";
+    public static final String MEMBER_CONSTRAINT_VIOLATION_EXCEPTION = "현재 참가하고 있는 방이 존재하기 때문에 회원탈퇴는 불가능합니다.";
     public static final String MEMBER_UID_ISNULL = "UID 값이 올바르지 않습니다.";
     public static final String MEMBER_EMAIL_ISNULL = "Email 값이 올바르지 않습니다.";
     public static final String MEMBER_PHONE_ISNULL = "연락처 값이 올바르지 않습니다.";

--- a/src/main/java/com/itaxi/server/exception/member/MemberConstraintViolationException.java
+++ b/src/main/java/com/itaxi/server/exception/member/MemberConstraintViolationException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 
 public class MemberConstraintViolationException extends MemberException {
     public MemberConstraintViolationException(HttpStatus httpStatus) {
-        super(Message.FAVOR_JOINER_DUPLICATED, httpStatus);
+        super(Message.MEMBER_DELETE_FAILED, httpStatus);
     }
 }

--- a/src/main/java/com/itaxi/server/exception/member/MemberDeleteFailedException.java
+++ b/src/main/java/com/itaxi/server/exception/member/MemberDeleteFailedException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 
 public class MemberDeleteFailedException extends MemberException {
     public MemberDeleteFailedException(HttpStatus httpStatus) {
-        super(Message.MEMBER_DELETE_FAILED, httpStatus);
+        super(Message.MEMBER_CONSTRAINT_VIOLATION_EXCEPTION, httpStatus);
     }
 }

--- a/src/main/java/com/itaxi/server/member/application/MemberService.java
+++ b/src/main/java/com/itaxi/server/member/application/MemberService.java
@@ -39,10 +39,12 @@ public class MemberService {
             List<Member> memberList = memberRepository.findAll();
 
             for(int i = 0; i<memberList.size(); i++){
-                if(memberList.get(i).getUid().equals(memberCreateRequestDTO.getUid()) && memberList.get(i).isDeleted()){
+                if(memberList.get(i).getEmail().equals(memberCreateRequestDTO.getEmail()) && memberList.get(i).isDeleted()){
                     Optional<Member> reMember = memberRepository.findMemberByUid(memberList.get(i).getUid());
                     if(reMember.isPresent()){
                         reMember.get().setDeleted(false);
+                        reMember.get().setUid(memberCreateRequestDTO.getUid());
+                        reMember.get().setPhone(memberCreateRequestDTO.getPhone());
                         memberRepository.save(reMember.get());
                         return "Success";
                     }

--- a/src/main/java/com/itaxi/server/member/application/MemberService.java
+++ b/src/main/java/com/itaxi/server/member/application/MemberService.java
@@ -148,7 +148,7 @@ public class MemberService {
             }
         }
         else {
-            throw new MemberConstraintViolationException(HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new MemberConstraintViolationException(HttpStatus.BAD_REQUEST);
         }
     }
 }


### PR DESCRIPTION
- 재회원가입 때는 email이 동일한지 확인한후 변경및 암호화된  uid 및 phone 로 정보를 수정하여 재저장한다.
- 에러 메세지가 잘못설정 되어있어서 수정함